### PR TITLE
Added Docker support. Run 'docker build -t yourname/spacetalk .' to bundle SpaceTalk into a production-ready Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.meteor/local
+packages/*/.build*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# https://github.com/chriswessels/meteor-tupperware
+FROM chriswessels/meteor-tupperware
+
+MAINTAINER SpaceTalk (https://github.com/SpaceTalk)
+
+# (optional) Bake runtime options into your image
+# ENV MONGO_URL="mongodb://url" MONGO_OPLOG_URL="mongodb://oplog_url" ROOT_URL="http://yourapp.com"


### PR DESCRIPTION
Please see: https://trello.com/c/NXdReUCv/64-docker-support-for-easily-running-in-production
