### PR TITLE
Double brackets only on messages

### DIFF
--- a/client/views/message/message.html
+++ b/client/views/message/message.html
@@ -16,7 +16,7 @@
           <textarea rows="1" cols="90" class="edit-message-input">{{_removeTrailingNewLine message}}</textarea>
         </div>
       {{else}}
-        <div class="message">{{#markdown}}{{#emoji}}{{{message}}}{{/emoji}}{{/markdown}}</div>
+        <div class="message">{{#markdown}}{{#emoji}}{{message}}{{/emoji}}{{/markdown}}</div>
       {{/if}}
     </div>
   </li>


### PR DESCRIPTION
Even with tripple brackets I was not able to type `<script>alert('test')</script>` and have it give me an alert. But with two brackets, markdown and emojis look good. We do still need to somehow handle the case when nothing gets printed when typing in things that don't render, like the alert example, so it's not just an empty message that shows up.
