### PR TITLE
improved duplicate channel prevention

### DIFF
--- a/client/css/_sweetalert-override.scss
+++ b/client/css/_sweetalert-override.scss
@@ -1,0 +1,12 @@
+.sweet-alert {
+  .channel-link {
+    background-color: transparent !important;
+    padding: 3px 5px 3px 5px;
+    font-size: 120%;
+    color: $primary;
+    font-weight: bold;
+    border: none;
+    box-shadow: none;
+    margin: 0;
+  }
+}

--- a/client/css/main.scss
+++ b/client/css/main.scss
@@ -9,3 +9,4 @@
 @import "user";
 @import "styles";
 @import "channel-info";
+@import "sweetalert-override";

--- a/client/views/channel/channel.js
+++ b/client/views/channel/channel.js
@@ -65,6 +65,10 @@ Channel = BlazeComponent.extendComponent({
             var value = this.find('textarea[name=message]').value;
             // Markdown requires double spaces at the end of the line to force line-breaks.
             value = value.replace("\n", "  \n");
+
+            // Prevent accepting empty message
+            if ($.trim(value) === "") return;
+
             this.find('textarea[name=message]').value = ''; // Clear the textarea.
             Messages.insert({
               // TODO: should be checked server side if the user is allowed to do this

--- a/client/views/left-sidebar/channel-form.js
+++ b/client/views/left-sidebar/channel-form.js
@@ -9,13 +9,16 @@ ChannelForm = BlazeComponent.extendComponent({
         // We are building an application, so we don't want the form to reload the page.
         event.preventDefault();
 
-        var name = $(event.target).find('[name=name]').val();
+        var currentForm = this.$('.left-sidebar-channels-add-form');
+        var inputField = $(event.target).find('[name=name]');
+        var name = inputField.val();
 
         // Allow only unique channel name
         Meteor.call('channels.add', currentTeamId(), name, function(err, result) {
           if (result) {
-            // Channel created, hide the form
-            this.$('.left-sidebar-channels-add-form').addClass('hidden');
+            // Channel created, clear the input and hide the form
+            inputField.val('');
+            currentForm.addClass('hidden');
           } else if (err) {
             switch(err.error) {
               case 401: // Not authorized
@@ -33,10 +36,28 @@ ChannelForm = BlazeComponent.extendComponent({
                 });
                 break;
               case 422: // Channel exists
+                var channel = Channels.findOne({teamId: currentTeamId(), name: name});
                 swal({
                   title: 'Channel name exists',
-                  text: 'Please consider joining the existing channel\nor create a different channel.',
-                  type: 'error'
+                  text: 'Please consider joining the existing channel <button class="channel-link confirm">#' + name + '</button><br>or create a different channel.',
+                  type: 'error',
+                  closeOnConfirm: false,
+                  showConfirmButton: false,
+                  showCancelButton: true,
+                  closeOnCancel: true,
+                  cancelButtonText: "OK",
+                  html: true
+                }, function(isConfirm) {
+                  // User wants to visit the existing channel,
+                  // clear the input and hide the form
+                  // and redirect to the requested channel
+                  if (isConfirm) {
+                    var team = currentTeam();
+                    inputField.val('');
+                    currentForm.addClass('hidden');
+                    swal.close();
+                    FlowRouter.go('channel', { team: team.slug, channel: channel.slug });
+                  }
                 });
                 break;
             }


### PR DESCRIPTION
Redirect the user directly to the existing channel, and clear the input field when necessary.

![redirect to channel link](https://cloud.githubusercontent.com/assets/167158/7789948/fb253cba-0227-11e5-8efc-c14f4a9c49df.png)
