### PR TITLE
#56 fix message editing focus issue

### DIFF
--- a/client/views/message/message.html
+++ b/client/views/message/message.html
@@ -12,9 +12,7 @@
         {{/if}}
       </div>
       {{#if isEditing.get}}
-        <div class="edit-box">
-          <textarea rows="1" cols="90" class="form-message-input">{{_removeTrailingNewLine message}}</textarea>
-        </div>
+        {{> messageEditBox}}
       {{else}}
         <div class="message">{{#markdown}}{{#emoji}}{{message}}{{/emoji}}{{/markdown}}</div>
       {{/if}}
@@ -24,6 +22,6 @@
 
 <template name="messageEditBox">
   <div class="edit-box">
-    <textarea rows="1" cols="90" class="form-message-input">{{message}}</textarea>
+    <textarea rows="1" cols="90" class="edit-message-input">{{_removeTrailingNewLine message}}</textarea>
   </div>
 </template>


### PR DESCRIPTION
#56 An click on the edit text area causes it to stop editing instead of moving the key cursor
