### PR TITLE
#56 use common style for message editing. Fix typo which prevented multiline support in message editing.

### DIFF
--- a/client/views/message/message.html
+++ b/client/views/message/message.html
@@ -22,6 +22,6 @@
 
 <template name="messageEditBox">
   <div class="edit-box">
-    <textarea cols="90" class="edit-message-input">{{_removeTrailingNewLine message}}</textarea>
+    <textarea cols="90" name="message" class="form-message-input">{{_removeTrailingNewLine message}}</textarea>
   </div>
 </template>

--- a/client/views/message/message.js
+++ b/client/views/message/message.js
@@ -5,14 +5,14 @@ Message = BlazeComponent.extendComponent({
 
   _onClickOutside: function (e) {
     var self = e.data.instance;
-    if (!$(e.target).is(self.$('.edit-message-input')) && !$(e.target).is(self.$('.edit'))) {
+    if (!$(e.target).is(self.$('.form-message-input')) && !$(e.target).is(self.$('.edit'))) {
       self.isEditing.set(false);
       $(document.body).unbind('click', self._onClickOutside);
     }
   },
 
   _focus: function () {
-    var input = this.find('.edit-message-input');
+    var input = this.find('.form-message-input');
     input.focus();
 
     if (input.setSelectionRange) {
@@ -76,10 +76,10 @@ Message = BlazeComponent.extendComponent({
           if (e.keyCode === 27 && !e.shiftKey) { // esc to cancel
             e.preventDefault();
             this.toggleEditMode();
-          } else if (e.keyCode === 13 && !e.shifKey) { // enter to save
+          } else if (e.keyCode === 13 && !e.shiftKey) { // enter to save
             e.preventDefault();
 
-            var content = this.find('.edit-message-input').value;
+            var content = this.find('.form-message-input').value;
             Messages.update(this.currentData()._id, {
               $set: { message: content }
             });


### PR DESCRIPTION
Use the same style for edit message as in create message.
Fix typo which prevented multiline support in edit message.
