### PR TITLE
JSHint and variable naming fixes (Fixes #66)

### DIFF
--- a/client/views/channel-info/channel-info.js
+++ b/client/views/channel-info/channel-info.js
@@ -5,7 +5,7 @@ ChannelInfo = BlazeComponent.extendComponent({
   onRendered: function () {
 
   },
-  events: function() {
+  events: function () {
     return [
     {
 

--- a/client/views/channel/channel.js
+++ b/client/views/channel/channel.js
@@ -45,7 +45,7 @@ Channel = BlazeComponent.extendComponent({
   date: function () {
     var dateNow = moment(this.currentData().timestamp).calendar();
 
-    if (!this.date || this.date != dateNow) {
+    if (!this.date || this.date !== dateNow) {
       return this.date = dateNow;
     }
   },
@@ -86,7 +86,7 @@ Channel = BlazeComponent.extendComponent({
             window.scrollTo(0, document.body.scrollHeight);
           }
         },
-        'click [data-action="remove-channel"]': function (event, template) {
+        'click [data-action="remove-channel"]': function (event) {
           event.preventDefault();
 
           if (!currentChannel()) {
@@ -143,7 +143,7 @@ Channel = BlazeComponent.extendComponent({
             });
           }
         },
-        'click [data-action="display-channel-info"]': function (event, template) {
+        'click [data-action="display-channel-info"]': function (event) {
           event.preventDefault();
           $('.channel-info').toggleClass('channel-info-out');
           $('.channel-content').toggleClass('channel-content-full');

--- a/client/views/home/home.js
+++ b/client/views/home/home.js
@@ -1,5 +1,5 @@
 Template.home.helpers({
-  'teams': function() {
+  'teams': function () {
     return Teams.find({});
   }
 });

--- a/client/views/left-sidebar/channel-form.js
+++ b/client/views/left-sidebar/channel-form.js
@@ -15,7 +15,7 @@ ChannelForm = BlazeComponent.extendComponent({
         if ($.trim(name) === "") return;
 
         // Allow only unique channel name
-        Meteor.call('channels.add', currentTeamId(), name, function(error, result) {
+        Meteor.call('channels.add', currentTeamId(), name, function (error, result) {
           if (result) {
             // Navigate to the new channel view
             var newChannel = Channels.findOne(result);
@@ -54,7 +54,7 @@ ChannelForm = BlazeComponent.extendComponent({
                   closeOnCancel: true,
                   cancelButtonText: "OK",
                   html: true
-                }, function(isConfirm) {
+                }, function (isConfirm) {
                   // User wants to visit the existing channel,
                   // clear the input and hide the form
                   // and redirect to the requested channel

--- a/client/views/left-sidebar/channel-form.js
+++ b/client/views/left-sidebar/channel-form.js
@@ -15,7 +15,7 @@ ChannelForm = BlazeComponent.extendComponent({
         if ($.trim(name) === "") return;
 
         // Allow only unique channel name
-        Meteor.call('channels.add', currentTeamId(), name, function(err, result) {
+        Meteor.call('channels.add', currentTeamId(), name, function(error, result) {
           if (result) {
             // Navigate to the new channel view
             var newChannel = Channels.findOne(result);
@@ -26,8 +26,8 @@ ChannelForm = BlazeComponent.extendComponent({
             // Channel created, clear the input and hide the form
             inputField.val('');
             currentForm.addClass('hidden');
-          } else if (err) {
-            switch(err.error) {
+          } else if (error) {
+            switch(error.error) {
               case 401: // Not authorized
                 swal({
                   title: 'Yikes! Something went wrong',

--- a/client/views/left-sidebar/left-sidebar.js
+++ b/client/views/left-sidebar/left-sidebar.js
@@ -18,27 +18,27 @@ LeftSidebar = BlazeComponent.extendComponent({
     }
   },
   activeChannelClass: function () {
-    return currentChannelId() == this.currentData()._id ? 'active' : '';
+    return currentChannelId() === this.currentData()._id ? 'active' : '';
   },
-  events: function() {
+  events: function () {
     return [
       {
-        'click .sign-out': function(event) {
+        'click .sign-out': function (event) {
           event.preventDefault();
 
-          Meteor.logout(function (err) {
-            if (!err) {
+          Meteor.logout(function (error) {
+            if (!error) {
               FlowRouter.go('home');
             }
           });
         },
 
-        'click .left-sidebar-user-show-dropdown': function(event) {
+        'click .left-sidebar-user-show-dropdown': function (event) {
           event.preventDefault();
 
           this.$(".left-sidebar-user-dropdown").toggleClass("hidden");
         }
       }
-    ]
+    ];
   }
 }).register('leftSidebar');

--- a/client/views/message/message.js
+++ b/client/views/message/message.js
@@ -3,9 +3,9 @@ Message = BlazeComponent.extendComponent({
     this.isEditing = new ReactiveVar(false);
   },
 
-  _onClickOutside: function (e) {
-    var self = e.data.instance;
-    if (!$(e.target).is(self.$('.form-message-input')) && !$(e.target).is(self.$('.edit'))) {
+  _onClickOutside: function (event) {
+    var self = event.data.instance;
+    if (!$(event.target).is(self.$('.form-message-input')) && !$(event.target).is(self.$('.edit'))) {
       self.isEditing.set(false);
       $(document.body).unbind('click', self._onClickOutside);
     }
@@ -87,6 +87,6 @@ Message = BlazeComponent.extendComponent({
             this.toggleEditMode();
           }
         }
-      }]
+      }];
   }
 }).register('message');

--- a/client/views/message/message.js
+++ b/client/views/message/message.js
@@ -67,17 +67,17 @@ Message = BlazeComponent.extendComponent({
   events: function () {
     return [
       {
-        'click .edit': function (e) {
-          e.preventDefault();
+        'click .edit': function (event) {
+          eventpreventDefault();
           this.toggleEditMode();
         },
 
-        'keydown .edit-box': function (e) {
-          if (e.keyCode === 27 && !e.shiftKey) { // esc to cancel
-            e.preventDefault();
+        'keydown .edit-box': function (event) {
+          if (event.keyCode === 27 && !event.shiftKey) { // esc to cancel
+            event.preventDefault();
             this.toggleEditMode();
-          } else if (e.keyCode === 13 && !e.shiftKey) { // enter to save
-            e.preventDefault();
+          } else if (event.keyCode === 13 && !event.shiftKey) { // enter to save
+            event.preventDefault();
 
             var content = this.find('.form-message-input').value;
             Messages.update(this.currentData()._id, {


### PR DESCRIPTION
Renames shortened `e` and `err` to `event` and `error`, plus some other JSHint errors in the client side.
