### PR TITLE
Get automatic scrolling down of page working right [NEEDS FEEDBACK]

### DIFF
--- a/client/lib/dom-utilities.js
+++ b/client/lib/dom-utilities.js
@@ -1,16 +1,11 @@
 /**
  * Scrolls down the page when the user is a at or nearly at the bottom of the page
  */
-scrollDown = function (force) {
+scrollDown = function () {
   // It has to be in a setTimeout or it won't
   // scroll all the way down for some reason
   setTimeout(function () {
-    // Check if the innerHeight + the scrollY position is higher than the offsetHeight - 200
-    if ((window.innerHeight + window.scrollY) >= (
-      Number(document.body.offsetHeight) - 200
-      ) || force) {
-      // Scroll down the page
-      window.scrollTo(0, document.body.scrollHeight);
-    }
+    // Scroll down the page
+    window.scrollTo(0, document.body.scrollHeight);
   }, 0);
 };

--- a/client/lib/dom-utilities.js
+++ b/client/lib/dom-utilities.js
@@ -1,0 +1,16 @@
+/**
+ * Scrolls down the page when the user is a at or nearly at the bottom of the page
+ */
+scrollDown = function (force) {
+  // It has to be in a setTimeout or it won't
+  // scroll all the way down for some reason
+  setTimeout(function () {
+    // Check if the innerHeight + the scrollY position is higher than the offsetHeight - 200
+    if ((window.innerHeight + window.scrollY) >= (
+      Number(document.body.offsetHeight) - 200
+      ) || force) {
+      // Scroll down the page
+      window.scrollTo(0, document.body.scrollHeight);
+    }
+  }, 0);
+};

--- a/client/views/channel/channel.js
+++ b/client/views/channel/channel.js
@@ -159,20 +159,3 @@ Channel = BlazeComponent.extendComponent({
       }];
   }
 }).register('channel');
-
-/**
- * Scrolls down the page when the user is a at or nearly at the bottom of the page
- */
-var scrollDown = function (force) {
-  // It has to be in a setTimeout or it won't
-  // scroll all the way down for some reason
-  setTimeout(function () {
-    // Check if the innerHeight + the scrollY position is higher than the offsetHeight - 200
-    if ((window.innerHeight + window.scrollY) >= (
-      Number(document.body.offsetHeight) - 200
-      ) || force) {
-      // Scroll down the page
-      window.scrollTo(0, document.body.scrollHeight);
-    }
-  }, 0);
-};

--- a/client/views/channel/channel.js
+++ b/client/views/channel/channel.js
@@ -4,9 +4,8 @@ Channel = BlazeComponent.extendComponent({
     // Listen for changes to reactive variables (such as FlowRouter.getParam()).
     self.autorun(function () {
       currentChannel() && self.subscribe('messages', currentChannelId(), function () {
-        // XXX: can't figure out to get this to consistently,
-        // on page load, it won't scroll down automatically
-        scrollDown();
+        // On channel load, scroll page to the bottom
+        scrollDown(true);
       });
     });
   },
@@ -91,7 +90,7 @@ Channel = BlazeComponent.extendComponent({
             this.$('textarea[name=message]').css({
               height: 37
             });
-            window.scrollTo(0, document.body.scrollHeight);
+            scrollDown();
           }
         },
         'click [data-action="remove-channel"]': function (event) {
@@ -164,14 +163,14 @@ Channel = BlazeComponent.extendComponent({
 /**
  * Scrolls down the page when the user is a at or nearly at the bottom of the page
  */
-var scrollDown = function () {
+var scrollDown = function (force) {
   // It has to be in a setTimeout or it won't
   // scroll all the way down for some reason
   setTimeout(function () {
     // Check if the innerHeight + the scrollY position is higher than the offsetHeight - 200
     if ((window.innerHeight + window.scrollY) >= (
       Number(document.body.offsetHeight) - 200
-      )) {
+      ) || force) {
       // Scroll down the page
       window.scrollTo(0, document.body.scrollHeight);
     }


### PR DESCRIPTION
To address #50 and some.

The incoming messages scrolling down works nice, but it doesn't work when a giant incoming message comes through, it only works for small messages that don't occupy 200px of height (but is this really an issue? If the message is that big, chances are you'll have to scroll back up to read it).

Also when you first load the page, and there are tons of messages, the page doesn't scroll down.

I need your help in figuring out a way to guarantee the page scrolling down after the last message has been rendered on initial page load.
