### PR TITLE
fix to include main.scss properly

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -9,7 +9,7 @@ markdown
 reactive-var
 accounts-password
 momentjs:moment
-fourseven:scss@3.1.1
+fourseven:scss
 copleykj:jquery-autosize
 tmeasday:gravatar
 meteorhacks:flow-layout

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -9,7 +9,7 @@ markdown
 reactive-var
 accounts-password
 momentjs:moment
-fourseven:scss
+fourseven:scss@3.1.1
 copleykj:jquery-autosize
 tmeasday:gravatar
 meteorhacks:flow-layout

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -21,7 +21,7 @@ ejson@1.0.6
 email@1.0.6
 fastclick@1.0.3
 fortawesome:fontawesome@4.3.0
-fourseven:scss@3.0.0
+fourseven:scss@3.1.1
 geojson-utils@1.0.3
 html-tools@1.0.4
 htmljs@1.0.4

--- a/scss.json
+++ b/scss.json
@@ -1,4 +1,4 @@
 {
   "useIndex" : true,
-  "indexFilePath" : "client\\css\\main.scss"
+  "indexFilePath" : "client/css/main.scss"
 }


### PR DESCRIPTION
Please check the actual fix here:
https://github.com/fourseven/meteor-scss/issues/86

This will get rid of the wired client\css\main.scss file from the project root folder as well, and make sure everyone deletes this file before pull the latest. A channel announcement would work I guess.
