### PR TITLE
Add indication for edited messages

### DIFF
--- a/client/block-helpers/linkify.js
+++ b/client/block-helpers/linkify.js
@@ -4,7 +4,7 @@ Blaze.Template.registerHelper("linkify", new Template('linkify', function () {
   if (view.templateContentBlock) {
     content = Blaze._toText(view.templateContentBlock, HTML.TEXTMODE.STRING);
   }
-  return HTML.Raw(linkify(content) + '<span class="cursor"></span>');
+  return HTML.Raw(linkify(content));
 }));
 
 var linkify = function (string) {

--- a/client/css/_channel.scss
+++ b/client/css/_channel.scss
@@ -75,6 +75,11 @@
       .cursor {
         display: inline-block;
       }
+
+      .info-text {
+        color: #b4b4b4;
+        font-size: 0.8em;
+      }
     }
     .username, h2 {
       color: $primary;

--- a/client/views/message/message.html
+++ b/client/views/message/message.html
@@ -20,6 +20,10 @@
           </span>
         {{/if}}
         <div class="message">{{#emojione}}{{#markdown}}{{#linkify}}{{message}}{{/linkify}}{{/markdown}}{{/emojione}}
+          {{#if modifiedTimestamp}}
+            <span class="info-text">&nbsp;(edited)</span>
+          {{/if}}
+          <span class="cursor"></span>
           {{#if messageUrls}}
             {{#each messageUrls}}
               {{> oembed url=this}}

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -22,6 +22,14 @@ Messages.before.insert(function (userId, message) {
   message.userId = userId;
 });
 
+Messages.before.update(function (userId, doc, fieldNames, modifier, options) {
+  modifier.$set = modifier.$set || {};
+  // Add modifiedTimestamp field only when message content really changed
+  if (modifier.$set.message != doc.message) {
+    modifier.$set.modifiedTimestamp = new Date();
+  }
+});
+
 Messages.allow({
   insert: function (userId, doc) {
     if (userId && doc.channelId) {


### PR DESCRIPTION
When message is edited timestamp will be saved (can be used in the future to display something like "edited 2 minutes ago"). Situation when new message content is the same as the previous one is handled so the timestamp won't be generated.
